### PR TITLE
fix: available regions

### DIFF
--- a/use-openai/main.bicep
+++ b/use-openai/main.bicep
@@ -22,27 +22,19 @@ param embeddingDeploymentName string
 @description('Specifies the location of the Azure Machine Learning workspace and dependent resources.')
 @allowed([
   'australiaeast'
-  'brazilsouth'
-  'canadacentral'
-  'centralus'
-  'eastasia'
+  'canadaeast'
   'eastus'
   'eastus2'
   'francecentral'
   'japaneast'
-  'koreacentral'
+  'swedencentral'
+  'switzerlandnorth'
   'northcentralus'
-  'northeurope'
-  'southeastasia'
-  'southcentralus'
+  'norwayeast'
   'uksouth'
-  'westcentralus'
   'westus'
-  'westus2'
   'westeurope'
-  'usgovvirginia'
-  'southafricanorth'
-  'southafricawest'
+  'southindia'
 ])
 param location string
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* While Azure AI Content Safety is available in most of the regions, Azure OpenAI Service is not. I mirrored all regions that were available during manual creation of the resource in the Azure Portal.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Fix
Fixes #1 

## How to Test
*  Get the code

```
git clone https://github.com/OscarSantosMu/rai-content-safety-workshop.git
cd rai-content-safety-workshop
git checkout fix/azopenai-regions
```

* Test
Follow the steps from [this lab](https://azure.github.io/responsible-ai-hub/docs/content-safety-resource)

## What to Check
Verify that the following are valid
* All regions should work as expected

## Other Information
<!-- Add any other helpful information that may be needed here. -->